### PR TITLE
Added removal of sensitive data when logged out

### DIFF
--- a/src/main/java/rs/teslaris/core/converter/institution/OrganisationUnitConverter.java
+++ b/src/main/java/rs/teslaris/core/converter/institution/OrganisationUnitConverter.java
@@ -1,6 +1,8 @@
 package rs.teslaris.core.converter.institution;
 
+import java.util.Objects;
 import java.util.stream.Collectors;
+import org.springframework.security.core.context.SecurityContextHolder;
 import rs.teslaris.core.converter.commontypes.GeoLocationConverter;
 import rs.teslaris.core.converter.commontypes.MultilingualContentConverter;
 import rs.teslaris.core.converter.commontypes.ResearchAreaConverter;
@@ -30,6 +32,18 @@ public class OrganisationUnitConverter {
         dto.setScopusAfid(organisationUnit.getScopusAfid());
         dto.setUris(organisationUnit.getUris());
 
+        filterSensitiveData(dto);
+
         return dto;
+    }
+
+    private static void filterSensitiveData(OrganisationUnitDTO organisationUnitResponse) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (Objects.isNull(authentication) || !authentication.isAuthenticated() ||
+            (authentication.getPrincipal() instanceof String &&
+                authentication.getPrincipal().equals("anonymousUser"))) {
+            organisationUnitResponse.getContact().setPhoneNumber("");
+        }
     }
 }

--- a/src/main/java/rs/teslaris/core/converter/person/ContactConverter.java
+++ b/src/main/java/rs/teslaris/core/converter/person/ContactConverter.java
@@ -1,6 +1,7 @@
 package rs.teslaris.core.converter.person;
 
 import java.util.Objects;
+import org.springframework.security.core.context.SecurityContextHolder;
 import rs.teslaris.core.dto.person.ContactDTO;
 import rs.teslaris.core.model.person.Contact;
 
@@ -14,6 +15,8 @@ public class ContactConverter {
             dto.setPhoneNumber(contact.getPhoneNumber());
         }
 
+        filterSensitiveData(dto);
+
         return dto;
     }
 
@@ -23,5 +26,16 @@ public class ContactConverter {
         contact.setPhoneNumber(contactDTO.getPhoneNumber());
 
         return contact;
+    }
+
+    private static void filterSensitiveData(ContactDTO contactResponse) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (Objects.isNull(authentication) || !authentication.isAuthenticated() ||
+            (authentication.getPrincipal() instanceof String &&
+                authentication.getPrincipal().equals("anonymousUser"))) {
+            contactResponse.setContactEmail("");
+            contactResponse.setPhoneNumber("");
+        }
     }
 }


### PR DESCRIPTION
## Description

Added removal of sensitive data when logged out so it won't be sent to the client and could not be harvested by any means.

## How should this be tested?

Try to browse persons, OUs or contributions. Sensitive data should not be fetched nor displayed. It should be available when you login though.

## Checklist

-   [x] I have tested these changes locally
-   [x] I have added tests that cover these changes (if applicable)
-   [x] I have updated the documentation (if applicable)
-   [x] I have added or updated the necessary comments in the code
