### PR TITLE
Fix/message source

### DIFF
--- a/src/main/java/rs/teslaris/assessment/util/ClassificationPriorityMapping.java
+++ b/src/main/java/rs/teslaris/assessment/util/ClassificationPriorityMapping.java
@@ -108,11 +108,16 @@ public class ClassificationPriorityMapping {
         return Optional.of(documentCode);
     }
 
+    @Nullable
     public static String getImaginaryDocClassificationCodeBasedOnCode(
         String classificationCode, PublicationType publicationType) {
 
         var documentCode =
             assessmentConfig.classificationToAssessmentMapping.get(classificationCode);
+
+        if (Objects.isNull(documentCode)) {
+            return null;
+        }
 
         if (publicationType instanceof JournalPublicationType) {
             if (documentCode.equals("M24") ||

--- a/src/main/java/rs/teslaris/assessment/util/ClassificationPriorityMapping.java
+++ b/src/main/java/rs/teslaris/assessment/util/ClassificationPriorityMapping.java
@@ -1,9 +1,7 @@
 package rs.teslaris.assessment.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nullable;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -14,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import rs.teslaris.assessment.model.AssessmentClassification;
@@ -24,6 +23,7 @@ import rs.teslaris.core.model.document.ProceedingsPublicationType;
 import rs.teslaris.core.model.document.PublicationType;
 import rs.teslaris.core.repository.document.JournalPublicationRepository;
 import rs.teslaris.core.repository.document.ProceedingsPublicationRepository;
+import rs.teslaris.core.util.ConfigurationLoaderUtil;
 import rs.teslaris.core.util.Pair;
 import rs.teslaris.core.util.exceptionhandling.exception.StorageException;
 
@@ -34,35 +34,34 @@ public class ClassificationPriorityMapping {
 
     private static JournalPublicationRepository journalPublicationRepository;
 
+    private static String externalOverrideConfiguration;
+
     private static AssessmentConfig assessmentConfig;
+
 
     @Autowired
     public ClassificationPriorityMapping(
         ProceedingsPublicationRepository proceedingsPublicationRepository,
-        JournalPublicationRepository journalPublicationRepository) {
+        JournalPublicationRepository journalPublicationRepository,
+        @Value("${assessment.classifications.priority-mapping}")
+        String externalOverrideConfiguration) {
         ClassificationPriorityMapping.proceedingsPublicationRepository =
             proceedingsPublicationRepository;
         ClassificationPriorityMapping.journalPublicationRepository = journalPublicationRepository;
+        ClassificationPriorityMapping.externalOverrideConfiguration = externalOverrideConfiguration;
         reloadConfiguration();
     }
 
     @Scheduled(fixedRate = (1000 * 60 * 10)) // 10 minutes
     private static void reloadConfiguration() {
         try {
-            loadConfiguration();
+            assessmentConfig = ConfigurationLoaderUtil.loadConfiguration(AssessmentConfig.class,
+                "src/main/resources/assessment/assessmentConfiguration.json",
+                externalOverrideConfiguration);
         } catch (IOException e) {
             throw new StorageException(
                 "Failed to reload indicator mapping configuration: " + e.getMessage());
         }
-    }
-
-    private static synchronized void loadConfiguration() throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        assessmentConfig = objectMapper.readValue(
-            new FileInputStream(
-                "src/main/resources/assessment/assessmentConfiguration.json"),
-            AssessmentConfig.class
-        );
     }
 
     public static Optional<Pair<AssessmentClassification, Set<MultiLingualContent>>> getClassificationBasedOnCriteria(

--- a/src/main/java/rs/teslaris/assessment/util/IndicatorMappingConfigurationLoader.java
+++ b/src/main/java/rs/teslaris/assessment/util/IndicatorMappingConfigurationLoader.java
@@ -1,16 +1,16 @@
 package rs.teslaris.assessment.util;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Nullable;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import rs.teslaris.core.indexmodel.statistics.StatisticsType;
+import rs.teslaris.core.util.ConfigurationLoaderUtil;
 import rs.teslaris.core.util.exceptionhandling.exception.StorageException;
 
 @Component
@@ -18,23 +18,27 @@ public class IndicatorMappingConfigurationLoader {
 
     private static IndicatorMappingConfiguration indicatorMappingConfiguration = null;
 
+    private static String externalOverrideConfiguration;
+
+
+    public IndicatorMappingConfigurationLoader(
+        @Value("${assessment.indicator.mapping}") String externalOverrideConfiguration) {
+        IndicatorMappingConfigurationLoader.externalOverrideConfiguration =
+            externalOverrideConfiguration;
+        reloadConfiguration();
+    }
+
     @Scheduled(fixedRate = (1000 * 60 * 10)) // 10 minutes
     private static void reloadConfiguration() {
         try {
-            loadConfiguration();
+            indicatorMappingConfiguration = ConfigurationLoaderUtil.loadConfiguration(
+                IndicatorMappingConfiguration.class,
+                "src/main/resources/assessment/indicatorMappingConfiguration.json",
+                externalOverrideConfiguration);
         } catch (IOException e) {
             throw new StorageException(
                 "Failed to reload indicator mapping configuration: " + e.getMessage());
         }
-    }
-
-    private static synchronized void loadConfiguration() throws IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
-        indicatorMappingConfiguration = objectMapper.readValue(
-            new FileInputStream(
-                "src/main/resources/assessment/indicatorMappingConfiguration.json"),
-            IndicatorMappingConfiguration.class
-        );
     }
 
     public static List<String> getIndicatorNameForLoaderMethodName(String methodName) {

--- a/src/main/java/rs/teslaris/core/configuration/BeanConfiguration.java
+++ b/src/main/java/rs/teslaris/core/configuration/BeanConfiguration.java
@@ -89,7 +89,7 @@ public class BeanConfiguration {
         var messageSource = new ReloadableResourceBundleMessageSource();
 
         String baseName = resolveValidMessageSourceBaseName();
-        messageSource.setBasename(baseName);
+        messageSource.setBasenames(baseName, "classpath:internationalization/messages");
         messageSource.setCacheSeconds(60 * 5);
         messageSource.setDefaultEncoding("UTF-8");
         messageSource.setFallbackToSystemLocale(true);

--- a/src/main/java/rs/teslaris/core/configuration/BeanConfiguration.java
+++ b/src/main/java/rs/teslaris/core/configuration/BeanConfiguration.java
@@ -3,6 +3,7 @@ package rs.teslaris.core.configuration;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import org.apache.tika.language.detect.LanguageDetector;
@@ -25,6 +26,10 @@ public class BeanConfiguration {
 
     @Value("${frontend.application.address}")
     private String frontendUrl;
+
+    @Value("${internationalization.message.location}")
+    private String messageSourceBasePackage;
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -76,7 +81,13 @@ public class BeanConfiguration {
     @Bean
     public MessageSource messageSource() {
         var messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasename("classpath:internationalization/messages");
+
+        if (Objects.nonNull(messageSourceBasePackage) && !messageSourceBasePackage.isBlank()) {
+            messageSource.setBasename("file:" + messageSourceBasePackage);
+        } else {
+            messageSource.setBasename("classpath:internationalization/messages");
+        }
+
         messageSource.setCacheSeconds(60 * 5);
         messageSource.setDefaultEncoding("UTF-8");
         messageSource.setFallbackToSystemLocale(true);

--- a/src/main/java/rs/teslaris/core/util/ConfigurationLoaderUtil.java
+++ b/src/main/java/rs/teslaris/core/util/ConfigurationLoaderUtil.java
@@ -1,0 +1,36 @@
+package rs.teslaris.core.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Objects;
+
+public class ConfigurationLoaderUtil {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static synchronized <T> T loadConfiguration(
+        Class<T> clazz,
+        String defaultConfigurationPath,
+        String overridePath
+    ) throws IOException {
+        T config = objectMapper.readValue(
+            new FileInputStream(defaultConfigurationPath),
+            clazz
+        );
+
+        // Checking for external override
+        if (Objects.isNull(overridePath) || overridePath.isBlank()) {
+            return config;
+        }
+
+        var externalFile = new File(overridePath);
+        if (externalFile.exists()) {
+            var updater = objectMapper.readerForUpdating(config);
+            config = updater.readValue(externalFile);
+        }
+
+        return config;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -107,6 +107,8 @@ export.base.url=${EXPORT_BASE_URL:http://localhost:8081}
 export.repo.name=CRIS UNS
 export.admin.email=chenejac@uns.ac.rs
 
+export.handler.configuration=
+
 # NOTIFICATIONS
 #notifications.schedule.daily=0 0 7 * * *
 notifications.schedule.daily=0 * * * * *
@@ -134,11 +136,16 @@ statistics.schedule.views=0 0 0 * * *
 statistics.schedule.downloads=0 0 1 * * *
 
 # ASSESSMENT FILES LOCATIONS
+assessment.classifications.priority-mapping=
+assessment.classifications.mapping=
 assessment.classifications.publication-series.mno=src/main/resources/publicationSeriesClassifications/mno
 assessment.indicators.publication-series.wos=src/main/resources/publicationSeriesIndicators/wos
 assessment.indicators.publication-series.erih-plus=src/main/resources/publicationSeriesIndicators/erihPlus
 assessment.indicators.publication-series.mks=src/main/resources/publicationSeriesIndicators/mks
 assessment.indicators.publication-series.scimago=src/main/resources/publicationSeriesIndicators/scimago
+assessment.rules.configuration=
+assessment.indicator.mapping=
+assessment.research-areas.mapping=
 
 # RECAPTCHA
 recaptcha.secret.key=${RECAPTCHA_SECRET_KEY:6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -162,3 +162,6 @@ rate-limiting.refill-period-seconds=1
 
 # VERSION
 app.version=${APP_VERSION:1.0.0}
+
+# INTERNATIONALIZATION
+internationalization.message.location=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -136,13 +136,15 @@ statistics.schedule.views=0 0 0 * * *
 statistics.schedule.downloads=0 0 1 * * *
 
 # ASSESSMENT FILES LOCATIONS
-assessment.classifications.priority-mapping=
-assessment.classifications.mapping=
 assessment.classifications.publication-series.mno=src/main/resources/publicationSeriesClassifications/mno
 assessment.indicators.publication-series.wos=src/main/resources/publicationSeriesIndicators/wos
 assessment.indicators.publication-series.erih-plus=src/main/resources/publicationSeriesIndicators/erihPlus
 assessment.indicators.publication-series.mks=src/main/resources/publicationSeriesIndicators/mks
 assessment.indicators.publication-series.scimago=src/main/resources/publicationSeriesIndicators/scimago
+
+# ASSESSMENT CONFIGURATION EXTERNAL OVERRIDES
+assessment.classifications.priority-mapping=
+assessment.classifications.mapping=
 assessment.rules.configuration=
 assessment.indicator.mapping=
 assessment.research-areas.mapping=

--- a/src/test/java/rs/teslaris/core/integration/DocumentPublicationControllerTest.java
+++ b/src/test/java/rs/teslaris/core/integration/DocumentPublicationControllerTest.java
@@ -65,18 +65,6 @@ public class DocumentPublicationControllerTest extends BaseTest {
             .andExpect(status().isNoContent());
     }
 
-    @Test
-    @WithMockUser(username = "test.researcher@test.com", password = "testResearcher")
-    public void testGetResearchOutputs() throws Exception {
-        String jwtToken = authenticateResearcherAndGetToken();
-
-        mockMvc.perform(MockMvcRequestBuilders.get(
-                    "http://localhost:8081/api/document/research-output/{documentId}", 10)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken))
-            .andExpect(status().isOk());
-    }
-
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     @WithMockUser(username = "test.researcher@test.com", password = "testResearcher")

--- a/src/test/java/rs/teslaris/core/integration/HealthCheckControllerTest.java
+++ b/src/test/java/rs/teslaris/core/integration/HealthCheckControllerTest.java
@@ -2,7 +2,6 @@ package rs.teslaris.core.integration;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;

--- a/src/test/java/rs/teslaris/core/integration/ThesisResearchOutputControllerTest.java
+++ b/src/test/java/rs/teslaris/core/integration/ThesisResearchOutputControllerTest.java
@@ -18,19 +18,6 @@ public class ThesisResearchOutputControllerTest extends BaseTest {
 
     @Test
     @WithMockUser(username = "test.librarian@test.com", password = "librarian")
-    public void testReadThesisResearchOutput() throws Exception {
-        String jwtToken = authenticateLibrarianAndGetToken();
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.get(
-                        "http://localhost:8081/api/thesis/research-output/{documentId}", 10)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + jwtToken))
-            .andExpect(status().isOk());
-    }
-
-    @Test
-    @WithMockUser(username = "test.librarian@test.com", password = "librarian")
     public void testAddThesisResearchOutput() throws Exception {
         String jwtToken = authenticateLibrarianAndGetToken();
 


### PR DESCRIPTION
## Description
Added a quick fix for messageSource bundle location specification through `.properties` file.

## How should this be tested?
Try to set `internationalization.message.location` property. If no value is specified, or no resources are present on said location, system should fall to default classpath location. If valid resource bundle is specified, system should use that resource bundle.

## Checklist

-   [x] I have tested these changes locally
-   [x] I have added tests that cover these changes (if applicable)
-   [x] I have updated the documentation (if applicable)
-   [x] I have added or updated the necessary comments in the code
